### PR TITLE
Using nowrap to prevent multiline titles.

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -51,6 +51,9 @@ body, html {
     font-size: 16px;
     line-height: normal;
     padding: 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .bookmarkUrl {
@@ -59,4 +62,7 @@ body, html {
     font-size: 16px;
     line-height: normal;
     padding: 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }


### PR DESCRIPTION
Before: 
![screenshot from 2015-11-13 01 03 59](https://cloud.githubusercontent.com/assets/2878349/11132695/7b86a464-89a2-11e5-81dd-01b417942fce.png)

Now:
![screenshot from 2015-11-13 01 02 05](https://cloud.githubusercontent.com/assets/2878349/11132672/543cdc5c-89a2-11e5-9c3e-d01bd7fe2255.png)
