### PR TITLE
Dedupe our dependencies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,7 @@
     },
     "background": {
         "scripts": [
+            "dist/shared.bundle.js",
             "dist/background.bundle.js"
         ],
         "persistent": false

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "dateformat": "^1.0.12",
         "fuzzaldrin-plus": "^0.2.0",
         "jquery": "~3.0.0-alpha1",
-        "lodash": "^3.10.1",
         "mustache": "^2.2.0",
         "withinviewport": "^1.0.0"
     }

--- a/src/frontend/bookmarks/matched.js
+++ b/src/frontend/bookmarks/matched.js
@@ -2,12 +2,11 @@
 
 const settings = require('./../settings.js');
 const FuzzaldrinPlus = require('fuzzaldrin-plus');
-const _ = require('lodash');
 
 const propertyKey = settings.get('propertyKey');
 const maxResults = settings.get('maxResults');
 
-const highlight = _.partial(require('./../match-highlighter.js'), {
+const highlight = require('./../match-highlighter.js').bind(null, {
     match: FuzzaldrinPlus.match,
     reduce: require('./../ranges-reducer.js'),
     wrap: (string) => '<b>' + string + '</b>'

--- a/static/getting-started.html
+++ b/static/getting-started.html
@@ -40,6 +40,8 @@
                 </div>
             </div>
         </div>
-        <script src="../dist/gettingStarted.bundle.js"></script>
+
+        <script defer type="text/javascript" src="../dist/shared.bundle.js"></script>
+        <script defer type="text/javascript" src="../dist/gettingStarted.bundle.js"></script>
     </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -15,6 +15,7 @@
             <div id="results" class="col-xs-12"></div>
         </div>
 
+        <script defer type="text/javascript" src="../dist/shared.bundle.js"></script>
         <script defer type="text/javascript" src="../dist/frontend.bundle.js"></script>
     </body>
 </html>

--- a/static/options.html
+++ b/static/options.html
@@ -25,6 +25,7 @@
             </div>
         </fieldset>
 
+        <script defer type="text/javascript" src="../dist/shared.bundle.js"></script>
         <script defer type="text/javascript" src="../dist/options.bundle.js"></script>
     </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,18 @@
+const webpack = require('webpack');
+
 module.exports = {
     entry: {
         background: './src/backend/background/background.js',
         options: './src/backend/options/options.js',
         gettingStarted: './src/backend/getting-started/getting-started.js',
-        frontend: './src/frontend/main.js'
+        frontend: './src/frontend/main.js',
+        shared: ['jquery']
     },
     output: {
         path: './dist',
         filename: '[name].bundle.js'
-    }
+    },
+    plugins: [
+        new webpack.optimize.CommonsChunkPlugin("shared", "shared.bundle.js")
+    ]
 };


### PR DESCRIPTION
Moves jQuery and Webpack runtime to shared module.
Side effect is that we need to inblude it on background page, but this is not a big deal IMO.

Before

```
28.11.2015  18:07             5 023 background.bundle.js
28.11.2015  18:12           769 866 frontend.bundle.js
28.11.2015  18:07           266 053 gettingStarted.bundle.js
28.11.2015  18:07           266 244 options.bundle.js
```

After

```
29.11.2015  18:55             3 711 background.bundle.js
29.11.2015  18:55            80 926 frontend.bundle.js
29.11.2015  18:55               891 gettingStarted.bundle.js
29.11.2015  18:55             1 104 options.bundle.js
29.11.2015  18:55           267 655 shared.bundle.js
```
